### PR TITLE
remove toFixed use on lock page

### DIFF
--- a/src/lib/components/Lock.svelte
+++ b/src/lib/components/Lock.svelte
@@ -84,7 +84,7 @@
 					{#key $balancesStore.sFlrBalance}<span
 							data-testid="sflr-balance"
 							in:fade={{ duration: 700 }}
-							>{Number(formatEther($balancesStore.sFlrBalance)).toFixed(4)}</span
+							>{Number(formatEther($balancesStore.sFlrBalance))}</span
 						>{/key}
 					<span>SFLR</span>
 				</div>
@@ -106,7 +106,7 @@
 					in:fade={{ duration: 700 }}
 					class="flex flex-row items-center gap-2"
 					data-testid="price-ratio"
-					>{Number(formatEther(priceRatio.toString())).toFixed(5)}
+					>{Number(formatEther(priceRatio.toString()))}
 
 					<svg width="20" height="20" viewBox="0 0 100 100">
 						<circle cx="50" cy="50" r="45" stroke="none" stroke-width="10" fill="none" />
@@ -136,7 +136,7 @@
 					}}
 					on:setValueToMax={() => {
 						assets = $balancesStore.sFlrBalance;
-						amountToLock = Number(formatEther($balancesStore.sFlrBalance.toString())).toFixed(5);
+						amountToLock = Number(formatEther($balancesStore.sFlrBalance.toString())).toString();
 					}}
 					bind:amount={amountToLock}
 					maxValue={$balancesStore.sFlrBalance}
@@ -174,7 +174,7 @@
 					class="flex w-1/4 flex-col items-center justify-center pb-12 pr-2 text-center text-white"
 				>
 					<img src={ftso} alt="ftso" class="w-1/2" />
-					{Number(formatEther(priceRatio.toString())).toFixed(5)}
+					{Number(formatEther(priceRatio.toString()))}
 				</div>
 				<img src={mintDia} alt="diagram" class="w-1/2" />
 				<div class="w-1/4"></div>
@@ -185,7 +185,7 @@
 			>
 				{#key priceRatio}
 					<span in:fade={{ duration: 700 }} data-testid="calculated-cysflr"
-						>{(+amountToLock * Number(formatEther(priceRatio.toString()))).toFixed(3)}</span
+						>{(+amountToLock * Number(formatEther(priceRatio.toString())))}</span
 					>
 				{/key}
 				<span>cysFLR</span>

--- a/src/lib/components/Lock.svelte
+++ b/src/lib/components/Lock.svelte
@@ -83,8 +83,7 @@
 				<div class="flex flex-row gap-4">
 					{#key $balancesStore.sFlrBalance}<span
 							data-testid="sflr-balance"
-							in:fade={{ duration: 700 }}
-							>{Number(formatEther($balancesStore.sFlrBalance))}</span
+							in:fade={{ duration: 700 }}>{Number(formatEther($balancesStore.sFlrBalance))}</span
 						>{/key}
 					<span>SFLR</span>
 				</div>
@@ -185,7 +184,7 @@
 			>
 				{#key priceRatio}
 					<span in:fade={{ duration: 700 }} data-testid="calculated-cysflr"
-						>{(+amountToLock * Number(formatEther(priceRatio.toString())))}</span
+						>{+amountToLock * Number(formatEther(priceRatio.toString()))}</span
 					>
 				{/key}
 				<span>cysFLR</span>

--- a/src/lib/components/Lock.test.ts
+++ b/src/lib/components/Lock.test.ts
@@ -47,7 +47,7 @@ describe('Lock Component', () => {
 		await waitFor(() => {
 			expect(screen.getByTestId('sflr-balance')).toBeInTheDocument();
 
-			expect(screen.getByTestId('sflr-balance')).toHaveTextContent('9.8760');
+			expect(screen.getByTestId('sflr-balance')).toHaveTextContent('9.876');
 			expect(screen.getByTestId('price-ratio')).toBeInTheDocument();
 		});
 	});
@@ -62,7 +62,7 @@ describe('Lock Component', () => {
 			const priceRatio = screen.getByTestId('price-ratio');
 			expect(priceRatio).toBeInTheDocument();
 			const calculatedCysflr = screen.getByTestId('calculated-cysflr');
-			expect(calculatedCysflr).toHaveTextContent('0.001');
+			expect(calculatedCysflr).toHaveTextContent('0.000746');
 		});
 	});
 


### PR DESCRIPTION
This pull request includes changes to the `Lock.svelte` component to adjust the number formatting for displayed values and updates the corresponding tests to reflect these changes.

Changes to number formatting:

* [`src/lib/components/Lock.svelte`](diffhunk://#diff-398c308534fcd53dff33843fc46c58a6010ff7e92a103eaebb2269f2f26cf1ceL86-R86): Removed the `toFixed` method from various instances where numbers are formatted, resulting in values no longer being rounded to a fixed number of decimal places. [[1]](diffhunk://#diff-398c308534fcd53dff33843fc46c58a6010ff7e92a103eaebb2269f2f26cf1ceL86-R86) [[2]](diffhunk://#diff-398c308534fcd53dff33843fc46c58a6010ff7e92a103eaebb2269f2f26cf1ceL109-R108) [[3]](diffhunk://#diff-398c308534fcd53dff33843fc46c58a6010ff7e92a103eaebb2269f2f26cf1ceL139-R138) [[4]](diffhunk://#diff-398c308534fcd53dff33843fc46c58a6010ff7e92a103eaebb2269f2f26cf1ceL177-R176) [[5]](diffhunk://#diff-398c308534fcd53dff33843fc46c58a6010ff7e92a103eaebb2269f2f26cf1ceL188-R187)

Updates to tests:

* [`src/lib/components/Lock.test.ts`](diffhunk://#diff-c69fdf162e76896f4a9dea0674b0b4cf5e572fe962d1ffd6377b5ea2adc3d331L50-R50): Updated expected text content in tests to match the new number formatting without fixed decimal places. [[1]](diffhunk://#diff-c69fdf162e76896f4a9dea0674b0b4cf5e572fe962d1ffd6377b5ea2adc3d331L50-R50) [[2]](diffhunk://#diff-c69fdf162e76896f4a9dea0674b0b4cf5e572fe962d1ffd6377b5ea2adc3d331L65-R65)

<img width="896" alt="image" src="https://github.com/user-attachments/assets/ee97dcd6-15dc-4d95-9f70-208d114a6ecc">
