### PR TITLE
center transaction text

### DIFF
--- a/src/lib/components/TransactionModal.svelte
+++ b/src/lib/components/TransactionModal.svelte
@@ -49,7 +49,7 @@
 				>
 					<h1 class="text-lg md:text-2xl">✅</h1>
 				</div>
-				<div class="flex flex-col gap-4 text-left">
+				<div class="flex flex-col gap-4 text-center">
 					<p
 						class="text-lg font-semibold text-gray-900 dark:text-white"
 						data-testid="success-status"


### PR DESCRIPTION
This pull request includes a small change to the `TransactionModal.svelte` file. The change modifies the alignment of text within a `div` from left-aligned to center-aligned.

* [`src/lib/components/TransactionModal.svelte`](diffhunk://#diff-14825181f60a9e79de145d6b97f041b758c41f46fb4d2664ed3d2741cfab3461L52-R52): Changed the `class` attribute of a `div` from `text-left` to `text-center` to center-align the text within the modal.