### PR TITLE
Prevent rounding on unlock, and set unlock amount to exact numbers

### DIFF
--- a/src/lib/components/ReceiptModal.svelte
+++ b/src/lib/components/ReceiptModal.svelte
@@ -24,7 +24,11 @@
 	const readableBalance = Number(formatEther(receipt.balance));
 	const tokenId = receipt.tokenId;
 
+	let isMaxSelected = false;
+
 	const checkBalance = () => {
+		if (isMaxSelected) return;
+		
 		if (readableAmountToRedeem === '' || readableAmountToRedeem === null) {
 			readableAmountToRedeem = '0.0';
 		}
@@ -32,6 +36,7 @@
 	};
 
 	const handleInput = (event: { detail: { value: string } }) => {
+		isMaxSelected = false;
 		readableAmountToRedeem = event.detail.value;
 		checkBalance();
 	};
@@ -87,7 +92,9 @@
 				on:input={handleInput}
 				data-testid="redeem-input"
 				on:setValueToMax={() => {
+					isMaxSelected = true;
 					amountToRedeem = maxRedeemable;
+					readableAmountToRedeem = Number(formatEther(maxRedeemable)).toString();
 				}}
 			/>
 		</div>

--- a/src/lib/components/ReceiptModal.svelte
+++ b/src/lib/components/ReceiptModal.svelte
@@ -94,6 +94,7 @@
 				on:input={handleInput}
 				data-testid="redeem-input"
 				on:setValueToMax={() => {
+					console.log('setValueToMax');
 					isMaxSelected = true;
 					amountToRedeem = maxRedeemable;
 					readableAmountToRedeem = Number(formatEther(maxRedeemable)).toString();

--- a/src/lib/components/ReceiptModal.svelte
+++ b/src/lib/components/ReceiptModal.svelte
@@ -21,6 +21,7 @@
 	let readableAmountToRedeem: string = '0.0';
 	let amountToRedeem = BigInt(0);
 	let sFlrToReceive = BigInt(0);
+	
 	const readableBalance = Number(formatEther(receipt.balance));
 	const tokenId = receipt.tokenId;
 
@@ -41,8 +42,9 @@
 		checkBalance();
 	};
 
-	$: maxRedeemable =
-		$balancesStore?.cysFlrBalance < erc1155balance ? $balancesStore.cysFlrBalance : erc1155balance;
+	$: maxRedeemable = ($balancesStore.cysFlrBalance ?? 0n) < (erc1155balance ?? 0n) 
+		? ($balancesStore.cysFlrBalance ?? 0n) 
+		: (erc1155balance ?? 0n);
 
 	$: if (amountToRedeem) {
 		readableAmountToRedeem = Number(formatEther(amountToRedeem)).toString();

--- a/src/lib/components/ReceiptModal.svelte
+++ b/src/lib/components/ReceiptModal.svelte
@@ -21,7 +21,7 @@
 	let readableAmountToRedeem: string = '0.0';
 	let amountToRedeem = BigInt(0);
 	let sFlrToReceive = BigInt(0);
-	
+
 	const readableBalance = Number(formatEther(receipt.balance));
 	const tokenId = receipt.tokenId;
 
@@ -29,7 +29,7 @@
 
 	const checkBalance = () => {
 		if (isMaxSelected) return;
-		
+
 		if (readableAmountToRedeem === '' || readableAmountToRedeem === null) {
 			readableAmountToRedeem = '0.0';
 		}
@@ -42,9 +42,10 @@
 		checkBalance();
 	};
 
-	$: maxRedeemable = ($balancesStore.cysFlrBalance ?? 0n) < (erc1155balance ?? 0n) 
-		? ($balancesStore.cysFlrBalance ?? 0n) 
-		: (erc1155balance ?? 0n);
+	$: maxRedeemable =
+		($balancesStore.cysFlrBalance ?? 0n) < (erc1155balance ?? 0n)
+			? ($balancesStore.cysFlrBalance ?? 0n)
+			: (erc1155balance ?? 0n);
 
 	$: if (amountToRedeem) {
 		readableAmountToRedeem = Number(formatEther(amountToRedeem)).toString();
@@ -94,7 +95,6 @@
 				on:input={handleInput}
 				data-testid="redeem-input"
 				on:setValueToMax={() => {
-					console.log('setValueToMax');
 					isMaxSelected = true;
 					amountToRedeem = maxRedeemable;
 					readableAmountToRedeem = Number(formatEther(maxRedeemable)).toString();

--- a/src/lib/components/ReceiptModal.test.ts
+++ b/src/lib/components/ReceiptModal.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/svelte';
+import { render, screen, waitFor, fireEvent } from '@testing-library/svelte';
 import ReceiptModal from './ReceiptModal.svelte';
 import transactionStore from '$lib/transactionStore';
 
@@ -116,6 +116,64 @@ describe('ReceiptModal Component', () => {
 
 		await waitFor(() => {
 			expect(initiateUnlockTransactionSpy).toHaveBeenCalledOnce();
+		});
+	});
+
+	it('should set exact receipt balance when max button is clicked and receipt balance is less than cysFlrBalance', async () => {
+		const mockCysFlrBalance = BigInt('1000000000000000000'); // 1 cysFLR
+		mockBalancesStore.mockSetSubscribeValue(mockCysFlrBalance, BigInt(1), 'Ready');
+
+		render(ReceiptModal, { receipt: mockReceipt });
+
+		// Find the max button within the input component and click it
+		const maxButton = screen.getByTestId('set-val-to-max');
+		await fireEvent.click(maxButton);
+
+
+		// Click unlock button
+
+		await waitFor(() => {
+			const unlockButton = screen.getByTestId('unlock-button');
+			expect(unlockButton.getAttribute('disabled')).toBeFalsy();
+			userEvent.click(unlockButton);
+		});
+
+		// Verify initiateUnlockTransaction was called with exact cysFlrBalance
+		await waitFor(() => {
+			expect(initiateUnlockTransactionSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					assets: mockReceipt.balance
+				})
+			);
+		});
+	});
+
+		it('should set cysFlrBalance when max button is clicked and receipt balance is greater than cysFlrBalance', async () => {
+		const mockCysFlrBalance = BigInt('100000000000'); // 1 cysFLR
+		mockBalancesStore.mockSetSubscribeValue(mockCysFlrBalance, BigInt(1), 'Ready');
+
+		render(ReceiptModal, { receipt: mockReceipt });
+
+		// Find the max button within the input component and click it
+		const maxButton = screen.getByTestId('set-val-to-max');
+		await fireEvent.click(maxButton);
+
+
+		// Click unlock button
+
+		await waitFor(() => {
+			const unlockButton = screen.getByTestId('unlock-button');
+			expect(unlockButton.getAttribute('disabled')).toBeFalsy();
+			userEvent.click(unlockButton);
+		});
+
+		// Verify initiateUnlockTransaction was called with exact cysFlrBalance
+		await waitFor(() => {
+			expect(initiateUnlockTransactionSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					assets: mockCysFlrBalance
+				})
+			);
 		});
 	});
 });

--- a/src/lib/components/ReceiptModal.test.ts
+++ b/src/lib/components/ReceiptModal.test.ts
@@ -129,7 +129,6 @@ describe('ReceiptModal Component', () => {
 		const maxButton = screen.getByTestId('set-val-to-max');
 		await fireEvent.click(maxButton);
 
-
 		// Click unlock button
 
 		await waitFor(() => {
@@ -148,7 +147,7 @@ describe('ReceiptModal Component', () => {
 		});
 	});
 
-		it('should set cysFlrBalance when max button is clicked and receipt balance is greater than cysFlrBalance', async () => {
+	it('should set cysFlrBalance when max button is clicked and receipt balance is greater than cysFlrBalance', async () => {
 		const mockCysFlrBalance = BigInt('100000000000'); // 1 cysFLR
 		mockBalancesStore.mockSetSubscribeValue(mockCysFlrBalance, BigInt(1), 'Ready');
 
@@ -157,7 +156,6 @@ describe('ReceiptModal Component', () => {
 		// Find the max button within the input component and click it
 		const maxButton = screen.getByTestId('set-val-to-max');
 		await fireEvent.click(maxButton);
-
 
 		// Click unlock button
 


### PR DESCRIPTION
- The max redeemable amount should be the lowest number out of receipt balance/cysFlrBalance
- Add tests in ReceiptModal for this behaviour