### PR TITLE
feat(ui): unlock sorting, token filtering, wallet balance clarity

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(printf \"host=github.com\\\\nprotocol=https\\\\n\")",
+      "Bash(git credential-osxkeychain erase)",
+      "Bash(git config --list)",
+      "WebFetch(domain:cyclo.site)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 src/generated.ts
 src/generated-graphql.ts
+# Claude Code local config
+.claude/
+CLAUDE.md

--- a/UI_CHANGE_LOG_2026-02-19.md
+++ b/UI_CHANGE_LOG_2026-02-19.md
@@ -1,0 +1,166 @@
+# Cyclo Finance — UI Patch Log
+
+**Date:** 2026-02-19
+**Scope:** UI-only corrections
+**Author:** Steven Hudspeth
+**Environment Tested:** Local dev + static preview build
+
+---
+
+## Summary
+
+This patch contains strictly presentation-layer improvements.
+No contract logic, store logic, polling, or data pipelines were modified.
+
+Changes fall into three categories:
+
+1. Unlock list sorting correction
+2. Token panel filtering on Unlock page + Footer
+3. Balance card labeling clarity improvement
+
+---
+
+## 1. Unlock List Sorting Fix
+
+### File
+
+`src/lib/components/ReceiptsTable.svelte`
+
+### Issue
+
+Unlock positions were not ordered by lock price.
+
+### Expected Behavior
+
+Positions sorted ascending by lock price (cyToken per locked underlying).
+Lowest lock price at top. Highest at bottom.
+
+### Implementation
+
+- Changed `mappedReceipts` from a one-time `const` to a reactive `$:` derived array.
+- Added `lockPrice` field computed from `tokenId` (formatted to 18 decimals).
+- Appended `.sort((a, b) => a.lockPrice - b.lockPrice)` to the mapped array.
+- Sorting occurs on a spread copy (`[...receipts]`).
+- Original `receipts` prop is not mutated.
+- Pure presentation-layer change.
+
+### Risk Level
+
+Low — no store or contract modifications.
+
+---
+
+## 2. Token Panel Filtering (Unlock + Footer)
+
+### Files
+
+- `src/lib/components/Unlock.svelte`
+- `src/lib/components/Footer.svelte`
+
+### Issue
+
+All tokens across networks rendered in panels regardless of selected token.
+
+### Fix — Unlock.svelte
+
+Restricted wallet balance rendering to selected token only:
+
+```svelte
+{#each $allTokens.filter((t) => t.name === $selectedCyToken?.name) as token}
+```
+
+### Fix — Footer.svelte
+
+Imported `selectedCyToken` from stores. Created reactive `filteredTokensByNetwork` that filters each network's tokens array to only the selected token, removing networks with zero matching tokens. Replaced `tokensByNetwork` with `filteredTokensByNetwork` in the template loop.
+
+### Impact
+
+- Cleaner UX — only relevant token panel shown
+- Reduced cognitive noise
+- No store modification
+- No change to data fetching
+
+### Risk Level
+
+Low — template-only filtering.
+
+---
+
+## 3. Wallet Balance Label Clarification
+
+### File
+
+`src/lib/components/Unlock.svelte`
+
+### Change
+
+Renamed:
+
+```
+BALANCES
+```
+
+to:
+
+```
+WALLET BALANCE
+```
+
+Added helper text:
+
+```
+cyToken balance in your wallet. Locked positions are listed below.
+```
+
+### Purpose
+
+Clarifies distinction between:
+
+- Wallet-held ERC20 balance
+- Locked positions (receipt NFTs)
+
+### Risk Level
+
+Minimal — text-only modification.
+
+---
+
+## Scope Confirmation
+
+| Area                  | Modified |
+| --------------------- | -------- |
+| Store logic           | No       |
+| Contract interactions | No       |
+| Polling intervals     | No       |
+| Generated files       | No       |
+| Root layout           | No       |
+| balancesStore.ts      | No       |
+| transactionStore.ts   | No       |
+| UI components only    | Yes      |
+
+---
+
+## Files Modified
+
+| File | Lines Changed |
+| ---- | ------------- |
+| `src/lib/components/ReceiptsTable.svelte` | +41 / -26 |
+| `src/lib/components/Unlock.svelte` | +5 / -2 |
+| `src/lib/components/Footer.svelte` | +12 / -2 |
+
+---
+
+## Testing Performed
+
+- Local dev server (`npm run dev`)
+- Static preview (`npm run build` + `npm run preview`)
+- Verified:
+  - Unlock sorting correct
+  - Token filtering correct on Unlock page and Footer
+  - No console errors
+  - No hydration issues
+  - No network polling regression
+
+---
+
+End of patch log.

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -3,7 +3,7 @@
 	import balancesStore from '$lib/balancesStore';
 	import { formatNumberWithAbbreviations } from '$lib/methods';
 	import { Spinner } from 'flowbite-svelte';
-	import { supportedNetworks, allTokens } from '$lib/stores';
+	import { supportedNetworks, allTokens, selectedCyToken } from '$lib/stores';
 
 	function calculateMarketCap(price: bigint, supply: bigint): bigint {
 		return (price * supply) / BigInt(1e6);
@@ -14,6 +14,16 @@
 		name: network.chain?.name ?? network.key,
 		tokens: network.tokens
 	}));
+
+	// Filter to only show the selected token's network/panel
+	$: filteredTokensByNetwork = $selectedCyToken
+		? tokensByNetwork
+				.map((network) => ({
+					...network,
+					tokens: network.tokens.filter((t) => t.name === $selectedCyToken.name)
+				}))
+				.filter((network) => network.tokens.length > 0)
+		: tokensByNetwork;
 
 	// Calculate globalTvl using allTokens to ensure all active tokens are included
 	// Normalize all usdTvl values to 18 decimals before summing since they're stored with token.decimals
@@ -66,7 +76,7 @@
 					<span>$ {Number(formatUnits(globalTvl, 18))}</span>
 				</div>
 			</div>
-			{#each tokensByNetwork as network (network.key)}
+			{#each filteredTokensByNetwork as network (network.key)}
 				<div class="flex flex-col gap-3 border-b border-white/20 pb-3 last:border-0">
 					<div class="flex items-center justify-between text-sm font-semibold uppercase">
 						<span>{network.name}</span>

--- a/src/lib/components/ReceiptsTable.svelte
+++ b/src/lib/components/ReceiptsTable.svelte
@@ -20,36 +20,41 @@
 	export let receipts: ReceiptType[];
 	let selectedReceipt: ReceiptType | null = null;
 
-	const mappedReceipts = receipts.map((receipt) => {
-		// Guard against undefined values
-		if (!receipt.balance || !receipt.tokenId) {
+	$: mappedReceipts = [...receipts]
+		.map((receipt) => {
+			// Guard against undefined values
+			if (!receipt.balance || !receipt.tokenId) {
+				return {
+					...receipt,
+					totalsFlr: BigInt(0),
+					lockPrice: 0,
+					readableFlrPerReceipt: '0.00000',
+					readableTotalsFlr: '0.00000'
+				};
+			}
+
+			const balance = BigInt(receipt.balance);
+			const tokenId = BigInt(receipt.tokenId);
+
+			// Calculate totals: (balance * 10^18) / tokenId
+			const totalsFlr = (balance * BigInt(10 ** 18)) / tokenId;
+
+			// Calculate per-receipt: 10^36 / tokenId
+			const flrPerReceipt = BigInt(10 ** 36) / tokenId;
+
+			// Lock price = tokenId in 18 decimals — the value displayed as
+			// "{token.name} per locked {token.underlyingSymbol}"
+			const lockPrice = Number(formatUnits(tokenId, 18));
+
 			return {
 				...receipt,
-				totalsFlr: BigInt(0),
-				readableFlrPerReceipt: '0.00000',
-				readableTotalsFlr: '0.00000'
+				totalsFlr,
+				lockPrice,
+				readableFlrPerReceipt: Number(formatUnits(flrPerReceipt, token.decimals)).toFixed(5),
+				readableTotalsFlr: Number(formatUnits(totalsFlr, token.decimals)).toFixed(5)
 			};
-		}
-
-		const balance = BigInt(receipt.balance);
-		const tokenId = BigInt(receipt.tokenId);
-
-		// Calculate totals: (balance * 10^18) / tokenId
-		// balance is in token.decimals, we scale to 18 decimals, then divide by tokenId (in 18 decimals)
-		// Result is total underlying token locked in 18 decimals
-		const totalsFlr = (balance * BigInt(10 ** 18)) / tokenId;
-
-		// Calculate per-receipt: 10^36 / tokenId
-		// This gives the cyToken per locked underlying token (in 18 decimals)
-		const flrPerReceipt = BigInt(10 ** 36) / tokenId;
-
-		return {
-			...receipt,
-			totalsFlr: totalsFlr,
-			readableFlrPerReceipt: Number(formatUnits(flrPerReceipt, token.decimals)).toFixed(5),
-			readableTotalsFlr: Number(formatUnits(totalsFlr, token.decimals)).toFixed(5)
-		};
-	});
+		})
+		.sort((a, b) => a.lockPrice - b.lockPrice);
 </script>
 
 <Card size="lg">

--- a/src/lib/components/Unlock.svelte
+++ b/src/lib/components/Unlock.svelte
@@ -142,9 +142,12 @@
 		<div
 			class="flex w-full flex-col justify-between font-semibold text-white sm:flex-row sm:text-xl md:text-xl"
 		>
-			<span>BALANCES</span>
+			<div class="flex flex-col">
+				<span>WALLET BALANCE</span>
+				<span class="text-xs font-normal text-gray-400">cyToken balance in your wallet. Locked positions are listed below.</span>
+			</div>
 			<div class="flex flex-col gap-4 sm:items-end">
-				{#each $allTokens as token}
+				{#each $allTokens.filter((t) => t.name === $selectedCyToken?.name) as token}
 					<div class="flex flex-row gap-2" data-testid="{token.symbol.toLowerCase()}-balance">
 						{#key $balancesStore.balances[token.name]?.signerBalance}
 							<span in:fade={{ duration: 700 }}>


### PR DESCRIPTION
## Summary
- **Unlock list sorting**: Positions now sorted ascending by lock price (lowest at top)
- **Token panel filtering**: Unlock page and Footer only show the selected token's panel, reducing clutter
- **Balance label clarity**: Renamed "BALANCES" to "WALLET BALANCE" with helper text distinguishing wallet balance from locked positions

## Details
UI-only changes — no store logic, contract interactions, or data pipelines were modified. See `UI_CHANGE_LOG_2026-02-19.md` for full patch notes.

## Test plan
- [ ] Verify unlock positions sort correctly by lock price
- [ ] Verify only the selected token panel appears on Unlock page and Footer
- [ ] Verify "WALLET BALANCE" label and helper text render correctly
- [ ] No console errors or hydration issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)