### PR TITLE
update flare rewards subgraph to 2026-04-09-ae4f

### DIFF
--- a/src/lib/subgraph-urls.ts
+++ b/src/lib/subgraph-urls.ts
@@ -1,2 +1,2 @@
 export const FLARE_REWARDS_SUBGRAPH_URL =
-	'https://api.goldsky.com/api/public/project_cm4zggfv2trr301whddsl9vaj/subgraphs/cyclo-flare/2026-04-06-99d3/gn';
+	'https://api.goldsky.com/api/public/project_cm4zggfv2trr301whddsl9vaj/subgraphs/cyclo-flare/2026-04-09-ae4f/gn';


### PR DESCRIPTION
## Summary
- Switch to `ae4f` subgraph which includes V3 cy/cy pool deposit matching fix

## Test plan
- [x] Subgraph verified as 100% synced and healthy
- [x] Self-consistency tests pass (except 1 known V2 entity ID bug, fix deploying)

🤖 Generated with [Claude Code](https://claude.com/claude-code)