### PR TITLE
update flare rewards subgraph to 2026-04-11-7c76

### DIFF
--- a/src/lib/subgraph-urls.ts
+++ b/src/lib/subgraph-urls.ts
@@ -1,2 +1,2 @@
 export const FLARE_REWARDS_SUBGRAPH_URL =
-	'https://api.goldsky.com/api/public/project_cm4zggfv2trr301whddsl9vaj/subgraphs/cyclo-flare/2026-04-09-ae4f/gn';
+	'https://api.goldsky.com/api/public/project_cm4zggfv2trr301whddsl9vaj/subgraphs/cyclo-flare/2026-04-11-7c76/gn';


### PR DESCRIPTION
## Summary
- Switch to `7c76` subgraph which includes LiquidityChange entity ID collision fix for cy/cy V2 pools

## Test plan
- [x] Subgraph 100% synced and healthy
- [x] Self-consistency and scrape integrity tests all pass on `7c76`
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)