### PR TITLE
feat: show re-up opportunity per receipt on unlock page

### DIFF
--- a/src/lib/components/ReceiptsTable.svelte
+++ b/src/lib/components/ReceiptsTable.svelte
@@ -14,20 +14,27 @@
 
   import ReceiptModal from "$lib/components/ReceiptModal.svelte";
   import Card from "./Card.svelte";
+  import balancesStore from "$lib/balancesStore";
 
   export let token: CyToken;
 
   export let receipts: ReceiptType[];
   let selectedReceipt: ReceiptType | null = null;
+  let showReup = true;
 
-  const mappedReceipts = receipts.map((receipt) => {
+  $: currentLockPrice = $balancesStore.stats[token.name]?.lockPrice ?? 0n;
+
+  $: mappedReceipts = receipts.map((receipt) => {
     // Guard against undefined values
     if (!receipt.balance || !receipt.tokenId) {
       return {
         ...receipt,
-        totalsFlr: BigInt(0),
+        totalsFlr: 0n,
         readableFlrPerReceipt: "0.00000",
         readableTotalsFlr: "0.00000",
+        readableReupPerUnderlying: "0.00000",
+        readableReupTotal: "0.00000",
+        reupTotal: 0n,
       };
     }
 
@@ -37,26 +44,63 @@
     // Calculate totals: (balance * 10^18) / tokenId
     // balance is in token.decimals, we scale to 18 decimals, then divide by tokenId (in 18 decimals)
     // Result is total underlying token locked in 18 decimals
-    const totalsFlr = (balance * BigInt(10 ** 18)) / tokenId;
+    const totalsFlr = (balance * 10n ** 18n) / tokenId;
 
     // Calculate per-receipt: 10^36 / tokenId
     // This gives the cyToken per locked underlying token (in 18 decimals)
-    const flrPerReceipt = BigInt(10 ** 36) / tokenId;
+    const flrPerReceipt = 10n ** 36n / tokenId;
+
+    // Re-up: if current lock price > the price at mint (tokenId), the receipt holder
+    // could mint additional cyToken without locking more underlying.
+    // addlPerUnderlying is in 18 decimals (USD price per 1 underlying).
+    // reupTotal is in token.decimals (matches balance/totalsFlr).
+    const addlPerUnderlying =
+      currentLockPrice > tokenId ? currentLockPrice - tokenId : 0n;
+    const reupTotal = (totalsFlr * addlPerUnderlying) / 10n ** 18n;
 
     return {
       ...receipt,
-      totalsFlr: totalsFlr,
+      totalsFlr,
       readableFlrPerReceipt: Number(
         formatUnits(flrPerReceipt, token.decimals),
       ).toFixed(5),
       readableTotalsFlr: Number(formatUnits(totalsFlr, token.decimals)).toFixed(
         5,
       ),
+      readableReupPerUnderlying: Number(
+        formatUnits(addlPerUnderlying, 18),
+      ).toFixed(5),
+      readableReupTotal: Number(
+        formatUnits(reupTotal, token.decimals),
+      ).toFixed(5),
+      reupTotal,
     };
   });
+
+  $: grandTotalReup = mappedReceipts.reduce(
+    (acc, r) => acc + (r.reupTotal ?? 0n),
+    0n,
+  );
+  $: readableGrandTotalReup = Number(
+    formatUnits(grandTotalReup, token.decimals),
+  ).toFixed(5);
 </script>
 
 <Card size="lg">
+  <div class="mb-2 flex w-full items-center justify-end text-white">
+    <label
+      class="flex cursor-pointer items-center gap-2"
+      title="Toggle visibility of re-up opportunity columns"
+    >
+      <input
+        type="checkbox"
+        bind:checked={showReup}
+        class="h-4 w-4"
+        data-testid="reup-toggle"
+      />
+      <span>Show re-up details</span>
+    </label>
+  </div>
   <Table divClass="w-full" data-testid="receipts-table">
     <TableHead
       class="bg-opacity-0 bg-none p-1 text-white md:p-4 [&_th]:px-2 [&_th]:md:px-6"
@@ -67,6 +111,18 @@
       <TableHeadCell
         >{token.name} per locked {token.underlyingSymbol}</TableHeadCell
       >
+      {#if showReup}
+        <TableHeadCell
+          title="Additional cyToken per 1 underlying = max(0, current lock price − original lock price (tokenId))"
+        >
+          Addl {token.name} per 1 {token.underlyingSymbol}
+        </TableHeadCell>
+        <TableHeadCell
+          title="Total additional cyToken = (Total {token.underlyingSymbol} locked for this receipt) × (Addl {token.name} per 1 {token.underlyingSymbol})"
+        >
+          Total addl {token.name}
+        </TableHeadCell>
+      {/if}
     </TableHead>
     <TableBody
       tableBodyClass="bg-opacity-0 [&_td]:text-white p-1 [&_td]:text-left [&_td]:px-2 [&_td]:md:px-6"
@@ -85,6 +141,20 @@
           <TableBodyCell data-testid={`locked-price-${index}`}>
             {Number(formatUnits(BigInt(receipt.tokenId), 18)).toFixed(5)}
           </TableBodyCell>
+          {#if showReup}
+            <TableBodyCell
+              data-testid={`reup-per-1-${index}`}
+              title={`current: ${Number(formatUnits(currentLockPrice, 18)).toFixed(5)}, original: ${Number(formatUnits(BigInt(receipt.tokenId), 18)).toFixed(5)} → addl = max(0, current − original)`}
+            >
+              {receipt.readableReupPerUnderlying}
+            </TableBodyCell>
+            <TableBodyCell
+              data-testid={`reup-total-${index}`}
+              title={`total addl = ${receipt.readableTotalsFlr} ${token.underlyingSymbol} × ${receipt.readableReupPerUnderlying} ${token.name}/${token.underlyingSymbol}`}
+            >
+              {receipt.readableReupTotal}
+            </TableBodyCell>
+          {/if}
           <TableBodyCell class="">
             <Button
               class="flex items-center justify-center rounded-none border-2 border-white bg-primary px-2 py-1 font-bold text-white transition-all hover:bg-blue-700 disabled:bg-neutral-600"
@@ -97,6 +167,19 @@
     </TableBody>
   </Table>
 </Card>
+
+{#if mappedReceipts.length && showReup}
+  <Card size="lg">
+    <div
+      class="flex w-full items-center justify-between font-semibold text-white"
+    >
+      <span>Re-up opportunity (total)</span>
+      <span data-testid="reup-total-sum"
+        >{readableGrandTotalReup} {token.name}</span
+      >
+    </div>
+  </Card>
+{/if}
 
 {#if selectedReceipt}
   <Modal


### PR DESCRIPTION
Closes #237. Reimplements #238 on a fresh branch off current main (multi-network).

## Summary
- Adds re-up visibility to the Unlock page: how much additional cyToken each receipt could mint at the current lock price without locking more underlying.
- New columns (toggleable): `Addl {token.name} per 1 {token.underlyingSymbol}` and `Total addl {token.name}`.
- Grand total card sums re-up across all visible receipts.

## Math
- `addlPerUnderlying = max(0, currentLockPrice − tokenId)` (both 18-decimal prices)
- `totalsFlr = (balance × 1e18) / tokenId` (in `token.decimals`)
- `reupTotal = (totalsFlr × addlPerUnderlying) / 1e18` (in `token.decimals`)

`currentLockPrice` reads `$balancesStore.stats[token.name].lockPrice`, so values recompute reactively when prices refresh.

## Differences from #238
- Uses `formatUnits(value, token.decimals)` / `formatUnits(value, 18)` instead of `formatEther`, since the multi-network refactor on main means `token.decimals` may not be 18 (e.g. cyWETH on Arbitrum).
- Computes `currentLockPrice` once at the top of the reactive block instead of per-receipt.

## Test plan
- [x] Existing `ReceiptsTable.test.ts` still passes
- [x] Full vitest suite (279 tests) passes
- [ ] Manually verify on Flare (cysFLR) that toggle hides/shows columns and grand total
- [ ] Manually verify on Arbitrum (cyWETH) that decimals render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)