### PR TITLE
fix(lock): derive assets reactively; preserve full precision on MAX (A17-3)

### DIFF
--- a/src/lib/components/Lock.svelte
+++ b/src/lib/components/Lock.svelte
@@ -35,10 +35,7 @@
   }
 
   // Derive assets reactively from amountToLock so the value the user sees
-  // in the input and the value submitted to the deposit can never drift.
-  // Pre-A17-3 this was an imperative checkBalance() call from on:input that
-  // could leave assets stale on any path that mutated amountToLock without
-  // dispatching input.
+  // in the input and the value submitted to the deposit cannot drift.
   $: assets = (() => {
     if (!amountToLock) return 0n;
     try {

--- a/src/lib/components/Lock.svelte
+++ b/src/lib/components/Lock.svelte
@@ -34,7 +34,19 @@
     READY = "LOCK",
   }
 
-  $: assets = BigInt(0);
+  // Derive assets reactively from amountToLock so the value the user sees
+  // in the input and the value submitted to the deposit can never drift.
+  // Pre-A17-3 this was an imperative checkBalance() call from on:input that
+  // could leave assets stale on any path that mutated amountToLock without
+  // dispatching input.
+  $: assets = (() => {
+    if (!amountToLock) return 0n;
+    try {
+      return parseUnits(amountToLock.toString(), $selectedCyToken.decimals);
+    } catch {
+      return 0n;
+    }
+  })();
   $: insufficientFunds =
     ($balancesStore.balances[$selectedCyToken.name]?.signerUnderlyingBalance ||
       0n) < assets;
@@ -43,10 +55,6 @@
     : insufficientFunds
       ? `INSUFFICIENT ${$selectedCyToken.underlyingSymbol}`
       : ButtonStatus.READY;
-
-  $: if ($signerAddress) {
-    checkBalance();
-  }
 
   // Auto-switch network when token is selected (only if network is different)
   $: if (
@@ -70,16 +78,6 @@
       );
     }
   }
-
-  const checkBalance = () => {
-    if (amountToLock) {
-      assets = parseUnits(amountToLock.toString(), $selectedCyToken.decimals);
-
-      insufficientFunds =
-        ($balancesStore.balances[$selectedCyToken.name]
-          ?.signerUnderlyingBalance ?? 0n) < assets;
-    }
-  };
 
   const initiateLockWithDisclaimer = () => {
     if (!disclaimerAcknowledged) {
@@ -237,16 +235,12 @@
           dataTestId="lock-input"
           on:input={(event) => {
             amountToLock = event.detail.value;
-            checkBalance();
           }}
           on:setValueToMax={() => {
             const balance =
               $balancesStore.balances[$selectedCyToken.name]
                 ?.signerUnderlyingBalance || 0n;
-            assets = balance;
-            amountToLock = Number(
-              formatUnits(balance, $selectedCyToken.decimals),
-            ).toString();
+            amountToLock = formatUnits(balance, $selectedCyToken.decimals);
           }}
           bind:amount={amountToLock}
           maxValue={$balancesStore.balances[$selectedCyToken.name]

--- a/src/lib/components/Lock.test.ts
+++ b/src/lib/components/Lock.test.ts
@@ -351,10 +351,10 @@ describe("Lock Component", () => {
   });
 
   it("should display the same amount it sends to handleLockTransaction when MAX is clicked", async () => {
-    // 18-decimal balance with all digits non-trivial. Pre-A17-3 setValueToMax
-    // ran the displayed amount through Number(formatUnits(...)).toString(),
-    // which truncates to ~15 sig figs while assets carried the full balance.
-    // The user saw a different number than they signed.
+    // 18-decimal balance with all digits non-trivial. A Number() round-trip
+    // on formatUnits would truncate to ~15 sig figs; the test guards
+    // against any path that introduces that drift between displayed amount
+    // and signed amount.
     const fullPrecisionBalance = 9876543210123456789n;
     mockBalancesStore.mockSetSubscribeValue(
       "Ready",

--- a/src/lib/components/Lock.test.ts
+++ b/src/lib/components/Lock.test.ts
@@ -8,6 +8,7 @@ import {
   mockWrongNetworkStore,
 } from "$lib/mocks/mockStores";
 import { parseEther } from "ethers";
+import { parseUnits } from "viem";
 
 const { mockBalancesStore } = await vi.hoisted(
   () => import("$lib/mocks/mockStores"),
@@ -347,6 +348,67 @@ describe("Lock Component", () => {
     await userEvent.click(acceptButton);
 
     expect(initiateLockTransactionSpy).not.toHaveBeenCalled();
+  });
+
+  it("should display the same amount it sends to handleLockTransaction when MAX is clicked", async () => {
+    // 18-decimal balance with all digits non-trivial. Pre-A17-3 setValueToMax
+    // ran the displayed amount through Number(formatUnits(...)).toString(),
+    // which truncates to ~15 sig figs while assets carried the full balance.
+    // The user saw a different number than they signed.
+    const fullPrecisionBalance = 9876543210123456789n;
+    mockBalancesStore.mockSetSubscribeValue(
+      "Ready",
+      false,
+      {
+        cyWETH: {
+          lockPrice: 0n,
+          price: 0n,
+          supply: 0n,
+          underlyingTvl: 0n,
+          usdTvl: 0n,
+        },
+        cysFLR: {
+          lockPrice: 1n,
+          price: 0n,
+          supply: 0n,
+          underlyingTvl: 0n,
+          usdTvl: 0n,
+        },
+      },
+      {
+        cyWETH: { signerBalance: 0n, signerUnderlyingBalance: 0n },
+        cysFLR: {
+          signerBalance: fullPrecisionBalance,
+          signerUnderlyingBalance: fullPrecisionBalance,
+        },
+      },
+      { cusdxOutput: 0n, cyTokenOutput: 0n },
+    );
+
+    render(Lock);
+
+    const maxButton = screen.getByTestId("set-val-to-max");
+    await userEvent.click(maxButton);
+
+    const input = screen.getByTestId("lock-input") as HTMLInputElement;
+    const displayedAmount = input.value;
+
+    const lockButton = screen.getByTestId("lock-button");
+    await userEvent.click(lockButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("disclaimer-modal")).toBeInTheDocument();
+    });
+
+    const acceptButton = screen.getByTestId("disclaimer-acknowledge-button");
+    await userEvent.click(acceptButton);
+
+    const callArgs = initiateLockTransactionSpy.mock.calls[0][0];
+    // Drift: displayed amount must equal signed amount.
+    expect(callArgs.assets).toBe(parseUnits(displayedAmount, 18));
+    // Truncation: signed amount must equal the full balance, not a Number()-
+    // round-tripped subset that leaves dust behind.
+    expect(callArgs.assets).toBe(fullPrecisionBalance);
   });
 
   it("should activate lock transaction when the disclaimer is accepted", async () => {


### PR DESCRIPTION
## Summary

Two related defects let the amount the user signed in the LOCK flow differ from the amount they saw in the input.

1. **`assets` was updated imperatively, not reactively.** Pre-fix: `$: assets = BigInt(0)` plus an imperative `checkBalance()` dispatched from `on:input`. Any path that mutated `amountToLock` without dispatching input would leave `assets` stale. Architectural drift class — easy for a future change to introduce a real divergence. Fix: `$: assets = !amountToLock ? 0n : parseUnits(amountToLock.toString(), $selectedCyToken.decimals)`.
2. **`setValueToMax` ran the displayed amount through `Number(formatUnits(balance, decimals)).toString()`.** Pre-fix: a balance like `9876543210123456789n` was displayed as `9.876543210123456` (Number truncates to ~15 sig figs) while the deposit signed `9.876543210123456789`. Fix: drop the `Number()` round-trip and use `formatUnits(balance, decimals)` directly.

Both fixes also remove the now-unused `checkBalance()` function, the `if ($signerAddress) checkBalance()` reactive, the `checkBalance()` call from the `Input` `on:input` handler, and the `assets = balance` line in `setValueToMax` (assets is derived now).

Closes #366.

## Test plan

- [x] new test asserts `assets` argument to `handleLockTransaction` equals `parseUnits(displayedAmount, 18)` (catches drift)
- [x] same test asserts `assets` equals the full-precision balance (catches truncation)
- [x] mutation: reverting the derivation to `$: assets = BigInt(0)` fails the drift assertion
- [x] mutation: bringing back `Number(formatUnits(...)).toString()` in `setValueToMax` fails the truncation assertion
- [x] full Lock test suite green (12/12)
- [x] `npm run check` clean (0 errors)
- [x] `npm run lint-check` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)