### PR TITLE
fix(lock): gate LOCK on price freshness, send 1% slippage as minSharesOut (A17-4)

### DIFF
--- a/src/lib/components/Lock.svelte
+++ b/src/lib/components/Lock.svelte
@@ -85,16 +85,25 @@
   };
 
   const runLockTransaction = () => {
-    // Defence-in-depth: the LOCK button is disabled on $wrongNetwork, but
-    // re-check synchronously in case the wallet chain changes between
-    // render and click (e.g. the disclaimer modal is acknowledged after
-    // a chain switch).
+    // Defence-in-depth: the LOCK button is disabled on these conditions,
+    // but re-check synchronously in case the underlying state changes
+    // between render and click (e.g. the disclaimer modal is acknowledged
+    // after a chain switch or after the price feed goes stale).
     if ($wrongNetwork) return;
+    const lockPrice = $balancesStore.stats[$selectedCyToken.name]?.lockPrice;
+    const cyTokenOutput = $balancesStore.swapQuotes.cyTokenOutput;
+    if (!lockPrice || !cyTokenOutput) return;
+    // 1% slippage on the contract-side minimum shares check. The contract
+    // re-reads its oracle at execution time and compares its computed share
+    // output against this floor; setting it to 0 (the previous value)
+    // accepted any positive share count, leaving sandwich attacks open.
+    const minSharesOut = (cyTokenOutput * 99n) / 100n;
     transactionStore.handleLockTransaction({
       signerAddress: $signerAddress,
       config: $wagmiConfig,
       selectedToken: $selectedCyToken,
       assets: assets,
+      minSharesOut,
     });
   };
 
@@ -391,7 +400,9 @@
         disabled={insufficientFunds ||
           !assets ||
           !amountToLock ||
-          $wrongNetwork}
+          $wrongNetwork ||
+          !$balancesStore.stats[$selectedCyToken.name]?.lockPrice ||
+          !$balancesStore.swapQuotes.cyTokenOutput}
         customClass="sm:text-xl text-lg w-full bg-white text-primary"
         dataTestId="lock-button"
         on:click={() => initiateLockWithDisclaimer()}>{buttonStatus}</Button

--- a/src/lib/components/Lock.test.ts
+++ b/src/lib/components/Lock.test.ts
@@ -85,7 +85,10 @@ describe("Lock Component", () => {
       },
       {
         cusdxOutput: BigInt(0),
-        cyTokenOutput: BigInt(0),
+        // Non-zero so the LOCK button isn't disabled by the
+        // missing-cyTokenOutput gate; tests that exercise that gate
+        // override this in their own mockSetSubscribeValue call.
+        cyTokenOutput: BigInt(1234000000000000000000n),
       },
     );
   });
@@ -382,7 +385,10 @@ describe("Lock Component", () => {
           signerUnderlyingBalance: fullPrecisionBalance,
         },
       },
-      { cusdxOutput: 0n, cyTokenOutput: 0n },
+      // Non-zero cyTokenOutput so the LOCK button isn't disabled by the
+      // missing-cyTokenOutput gate; this test is about MAX precision, not
+      // the price-freshness gate.
+      { cusdxOutput: 0n, cyTokenOutput: 1234000000000000000000n },
     );
 
     render(Lock);
@@ -409,6 +415,133 @@ describe("Lock Component", () => {
     // Truncation: signed amount must equal the full balance, not a Number()-
     // round-tripped subset that leaves dust behind.
     expect(callArgs.assets).toBe(fullPrecisionBalance);
+  });
+
+  it("should disable the lock button when lockPrice is missing", async () => {
+    mockBalancesStore.mockSetSubscribeValue(
+      "Ready",
+      false,
+      {
+        cyWETH: {
+          lockPrice: 0n,
+          price: 0n,
+          supply: 0n,
+          underlyingTvl: 0n,
+          usdTvl: 0n,
+        },
+        cysFLR: {
+          lockPrice: 0n,
+          price: 0n,
+          supply: 0n,
+          underlyingTvl: 0n,
+          usdTvl: 0n,
+        },
+      },
+      {
+        cyWETH: { signerBalance: 0n, signerUnderlyingBalance: 0n },
+        cysFLR: {
+          signerBalance: 9876000000000000000n,
+          signerUnderlyingBalance: 9876000000000000000n,
+        },
+      },
+      { cusdxOutput: 0n, cyTokenOutput: 1234000000000000000000n },
+    );
+    render(Lock);
+
+    const input = screen.getByTestId("lock-input");
+    await userEvent.type(input, "0.5");
+
+    const lockButton = screen.getByTestId("lock-button");
+    expect(lockButton).toBeDisabled();
+  });
+
+  it("should disable the lock button when swap-quote cyTokenOutput is zero", async () => {
+    mockBalancesStore.mockSetSubscribeValue(
+      "Ready",
+      false,
+      {
+        cyWETH: {
+          lockPrice: 0n,
+          price: 0n,
+          supply: 0n,
+          underlyingTvl: 0n,
+          usdTvl: 0n,
+        },
+        cysFLR: {
+          lockPrice: 1n,
+          price: 0n,
+          supply: 0n,
+          underlyingTvl: 0n,
+          usdTvl: 0n,
+        },
+      },
+      {
+        cyWETH: { signerBalance: 0n, signerUnderlyingBalance: 0n },
+        cysFLR: {
+          signerBalance: 9876000000000000000n,
+          signerUnderlyingBalance: 9876000000000000000n,
+        },
+      },
+      { cusdxOutput: 0n, cyTokenOutput: 0n },
+    );
+    render(Lock);
+
+    const input = screen.getByTestId("lock-input");
+    await userEvent.type(input, "0.5");
+
+    const lockButton = screen.getByTestId("lock-button");
+    expect(lockButton).toBeDisabled();
+  });
+
+  it("should pass minSharesOut as 99% of swap-quote cyTokenOutput to handleLockTransaction", async () => {
+    const cyTokenOutput = 1234000000000000000000n;
+    const expectedMinSharesOut = (cyTokenOutput * 99n) / 100n;
+    mockBalancesStore.mockSetSubscribeValue(
+      "Ready",
+      false,
+      {
+        cyWETH: {
+          lockPrice: 0n,
+          price: 0n,
+          supply: 0n,
+          underlyingTvl: 0n,
+          usdTvl: 0n,
+        },
+        cysFLR: {
+          lockPrice: 1n,
+          price: 0n,
+          supply: 0n,
+          underlyingTvl: 0n,
+          usdTvl: 0n,
+        },
+      },
+      {
+        cyWETH: { signerBalance: 0n, signerUnderlyingBalance: 0n },
+        cysFLR: {
+          signerBalance: 9876000000000000000n,
+          signerUnderlyingBalance: 9876000000000000000n,
+        },
+      },
+      { cusdxOutput: 0n, cyTokenOutput },
+    );
+    render(Lock);
+
+    const input = screen.getByTestId("lock-input");
+    await userEvent.type(input, "0.0005");
+
+    const lockButton = screen.getByTestId("lock-button");
+    await userEvent.click(lockButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("disclaimer-modal")).toBeInTheDocument();
+    });
+
+    const acceptButton = screen.getByTestId("disclaimer-acknowledge-button");
+    await userEvent.click(acceptButton);
+
+    expect(initiateLockTransactionSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ minSharesOut: expectedMinSharesOut }),
+    );
   });
 
   it("should activate lock transaction when the disclaimer is accepted", async () => {

--- a/src/lib/transactionStore.test.ts
+++ b/src/lib/transactionStore.test.ts
@@ -237,6 +237,7 @@ describe("transactionStore", () => {
       config: mockWagmiConfigStore as unknown as Config,
       selectedToken: mockSelectedToken,
       assets: mockAssets,
+      minSharesOut: 0n,
     });
     reset();
     expect(get(transactionStore)).toEqual({
@@ -259,6 +260,7 @@ describe("transactionStore", () => {
       config: mockWagmiConfigStore as unknown as Config,
       selectedToken: mockSelectedToken,
       assets: BigInt(1000),
+      minSharesOut: 0n,
     });
 
     awaitWalletConfirmation(
@@ -280,15 +282,27 @@ describe("transactionStore", () => {
       chainId: 1,
     });
 
+    const assets = BigInt(100);
+    const minSharesOut = BigInt(99);
     await handleLockTransaction({
       signerAddress: mockSignerAddress,
       config: mockWagmiConfigStore as unknown as Config,
       selectedToken: mockSelectedToken,
-      assets: BigInt(100),
+      assets,
+      minSharesOut,
     });
     expect(balancesStore.refreshBalances).toHaveBeenCalledWith(
       mockWagmiConfigStore,
       mockSignerAddress,
+    );
+    // The deposit must be invoked with the caller-supplied minSharesOut.
+    // Pre-fix this position was hardcoded to 0n, accepting any positive
+    // share count and leaving the user open to oracle-update sandwich.
+    expect(writeErc20PriceOracleReceiptVaultDeposit).toHaveBeenCalledWith(
+      mockWagmiConfigStore,
+      expect.objectContaining({
+        args: [assets, mockSignerAddress, minSharesOut, "0x"],
+      }),
     );
 
     expect(get(transactionStore).status).toBe(TransactionStatus.SUCCESS);
@@ -309,6 +323,7 @@ describe("transactionStore", () => {
       config: mockWagmiConfigStore as unknown as Config,
       selectedToken: mockSelectedToken,
       assets,
+      minSharesOut: 0n,
     });
 
     await waitFor(() => {
@@ -331,6 +346,7 @@ describe("transactionStore", () => {
       config: mockWagmiConfigStore as unknown as Config,
       selectedToken: mockSelectedToken,
       assets: BigInt(100),
+      minSharesOut: 0n,
     });
 
     expect(get(transactionStore).status).toBe(TransactionStatus.ERROR);
@@ -376,6 +392,7 @@ describe("transactionStore", () => {
       config: mockWagmiConfigStore as unknown as Config,
       selectedToken: mockSelectedToken,
       assets: BigInt(100),
+      minSharesOut: 0n,
     });
 
     expect(get(transactionStore).status).toBe(TransactionStatus.ERROR);

--- a/src/lib/transactionStore.ts
+++ b/src/lib/transactionStore.ts
@@ -56,6 +56,7 @@ export type initiateLockTransactionArgs = {
   signerAddress: string | null;
   selectedToken: CyToken;
   assets: bigint;
+  minSharesOut: bigint;
   config: Config;
 };
 
@@ -134,6 +135,7 @@ const transactionStore = () => {
     config,
     selectedToken,
     assets,
+    minSharesOut,
   }: initiateLockTransactionArgs) => {
     const writeLock = async () => {
       let hash: Hex | undefined;
@@ -142,7 +144,7 @@ const transactionStore = () => {
         awaitWalletConfirmation("Awaiting wallet confirmation to lock...");
         hash = await writeErc20PriceOracleReceiptVaultDeposit(config, {
           address: selectedToken.address,
-          args: [assets, signerAddress as Hex, 0n, "0x"],
+          args: [assets, signerAddress as Hex, minSharesOut, "0x"],
         });
       } catch (e) {
         console.log(e);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -45,6 +45,7 @@ export type InitiateLockTransactionArgs = {
   config: Config;
   selectedToken: CyToken;
   assets: bigint;
+  minSharesOut: bigint;
 };
 
 export type RewardsPools = Record<string, bigint>;


### PR DESCRIPTION
## Summary

Three fixes for an audit finding where a Lock deposit could go through with no on-chain slippage floor:

1. **LOCK button gates on `lockPrice`.** Was enabled when the price was missing/zero (UI already said "Stale or Incorrect price" but didn't block the click). Added to disabled and re-checked synchronously in `runLockTransaction`.
2. **LOCK button gates on swap-quote `cyTokenOutput`.** Was enabled before `refreshDepositPreviewSwapValue` first resolved (default 0n). Added to disabled and the synchronous re-check.
3. **Deposit submits with 1% slippage instead of 0.** `runLockTransaction` now computes `minSharesOut = cyTokenOutput * 99n / 100n` and threads it through `InitiateLockTransactionArgs` to the deposit call. The vault's pre-fix arg was `0n`, accepting any positive output and leaving an oracle-update sandwich vector.

The 1% slippage is hardcoded for now. A configurable slippage UI is a separate UX scope.

## Test plan

- [x] LOCK button disabled when `lockPrice` is missing — new Lock.test.ts test
- [x] LOCK button disabled when `cyTokenOutput` is zero — new Lock.test.ts test
- [x] `handleLockTransaction` is called with `minSharesOut === cyTokenOutput * 99n / 100n` — new Lock.test.ts test
- [x] Deposit args include caller-supplied `minSharesOut` — extended transactionStore "successful lock" test (catches the hardcoded-0n regression)
- [x] Mutation: dropping the lockPrice / cyTokenOutput gate fails both button-disabled tests
- [x] Mutation: reverting `minSharesOut` to `0n` in deposit args fails transactionStore success-path test
- [x] svelte-check 0 errors / eslint clean / 283/283 vitest pass
- [ ] CI green

Closes #368.

🤖 Generated with [Claude Code](https://claude.com/claude-code)